### PR TITLE
Link NUSPI project card directly to external site

### DIFF
--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -82,7 +82,7 @@ const Projects = () => {
           { name: 'Elementor', image: elementorLogo },
         ],
         detailDescription: t('project4_detailDescription'),
-        projectLocation: '/nuspi-project.html',
+        projectLocation: 'https://www.netwerkuspinclusief.nl/',
         className: 'animate__animated animate__bounceIn nuspi',
         wowDelay: '1.1s',
         tag: 'work',


### PR DESCRIPTION
## Summary
- update the NUSPI project card to open the live Netwerk USP Inclusief site directly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d13951aaa48327b6da6dc13ec0f023