### PR TITLE
Revamp project cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -672,175 +672,203 @@ body {
 }
 .projects-cards {
   display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
   flex-wrap: wrap;
-  gap: 30px;
+  justify-content: center;
+  align-items: stretch;
+  gap: 32px;
   padding: 0 20px;
   min-height: 300px;
 }
 .card {
-  width: 300px;
-  background-color: var(--secondary);
-  border-radius: 10px;
-  box-shadow: 0 1px 10px 1px #000;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 15px;
-  gap: 15px;
-  transition: 0.5s;
-  text-align: center;
-  max-height: 550px;
-}
-.card:hover {
-  transform: scale(1.02);
-  cursor: pointer;
-  box-shadow: 0 0 10px 0 var(--primary);
-}
-.card img {
-  object-fit: cover;
-  width: 270px;
-  height: 270px;
-  border-radius: 20px;
-}
-#spark,
-.nuspi img,
-.spark img {
-  object-fit: contain;
-}
-.card hr {
-  width: 95%;
-  opacity: 0.5;
-}
-.card .project-skills {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  gap: 25px;
-}
-.card .project-skills img {
-  width: 40px;
-  height: 40px;
-  border-radius: 0;
-  object-fit: contain;
-}
-.card p {
-  font-family: "Hind Madurai", sans-serif;
-  font-weight: 00px;
-  opacity: 0.8;
-}
-.card.expanded {
-  width: 500px;
-  height: 100%;
-  max-height: 1000px;
-  transition: 0.4s;
-  padding: 35px 35px 25px;
-  overflow: hidden;
-}
-.card.expanded .front-card,
-.card.expanded .project-skills,
-.project-details,
-label input {
-  display: none;
-}
-.card.expanded .project-details {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  text-align: left;
-  width: 100%;
-  height: 100%;
-  gap: 10px;
   position: relative;
+  width: min(100%, 320px);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  box-shadow: 0 18px 30px -20px rgba(0, 0, 0, 0.9);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 22px;
+  text-align: left;
+  overflow: hidden;
+  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+  cursor: pointer;
 }
-.card.expanded:hover {
-  transform: scale(1);
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(50, 132, 255, 0.22), rgba(50, 132, 255, 0));
+  opacity: 0;
+  transition: opacity 0.35s ease;
+  pointer-events: none;
+}
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+.card:hover,
+.card:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 40px -18px rgba(0, 0, 0, 0.9);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+.card:hover::before,
+.card.expanded::before,
+.card:focus-visible::before {
+  opacity: 1;
+}
+.card:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 4px;
 }
 .front-card {
-  gap: 15px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 18px;
+  text-align: center;
+  transition: opacity 0.35s ease, transform 0.35s ease, filter 0.35s ease;
+}
+.card-media {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  border-radius: 14px;
+  overflow: hidden;
+  background-color: rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+.project-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.nuspi .project-image,
+.spark .project-image,
+#spark .project-image {
+  object-fit: contain;
+  background-color: transparent;
+}
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.card-body h3 {
+  font-size: 1.35rem;
+  margin: 0;
+}
+.card-body p {
+  margin: 0;
+  font-family: 'Hind Madurai', sans-serif;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.6;
+}
+.project-skills {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.skill-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.9);
+  letter-spacing: 0.01em;
+  transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease;
+}
+.skill-pill:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+.skill-pill img {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+}
+.project-details {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: linear-gradient(180deg, rgba(8, 12, 22, 0.98), rgba(8, 12, 22, 0.94));
+  padding: 24px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(16px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  pointer-events: none;
+  overflow-y: auto;
+}
+.card.expanded {
+  cursor: default;
+}
+.card.expanded .front-card {
+  opacity: 0;
+  transform: scale(0.97);
+  filter: blur(2px);
+}
+.card.expanded .project-details {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 .project-details .close {
   display: flex;
-  flex-direction: row;
   justify-content: flex-end;
-  position: absolute;
-  top: -15px;
-  right: -15px;
+}
+.project-details h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+.project-details p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.82);
+  line-height: 1.6;
+  text-align: left;
+}
+.project-details .close-button {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.3s ease, color 0.3s ease;
+}
+.project-details .close-button:hover {
+  background: var(--primary);
+  color: #000;
+  transform: rotate(90deg);
 }
 .button.result {
   width: fit-content;
   text-align: center;
   font-size: 1rem;
-  padding: 5px 10px;
-  margin-top: 10px;
+  padding: 8px 16px;
+  margin-top: auto;
   font-weight: 600;
-  justify-self: flex-start;
-  display: flex;
-  flex-wrap: nowrap;
-  text-wrap: nowrap;
-  justify-content: space-between;
+  display: inline-flex;
   align-items: center;
+  gap: 12px;
   border: none;
-  gap: 16px;
-}
-.close-button {
-  background: var(--primary);
-  border: none;
-  height: 30px;
-  width: 30px;
-  border-radius: 5px;
-  cursor: pointer;
-  padding: 0;
-}
-.skill-tooltip {
-  position: relative;
-  display: inline-block;
-  cursor: pointer;
-}
-.tooltip,
-.tooltip-text {
-  visibility: hidden;
-  width: 200px;
-  text-wrap: wrap;
-  background-color: var(--secondary);
-  color: #000;
-  text-align: center;
-  border-radius: 6px;
-  padding: 10px;
-  position: absolute;
-  z-index: 1;
-  top: 90px;
-  left: 50%;
-  margin-left: -60%;
-  opacity: 0;
-  transition: opacity 0.5s;
-  font-weight: 500;
-}
-.filter-icon,
-.tooltip-text {
-  background-color: var(--primary);
-}
-.tooltip-text {
-  padding: 10px;
-  width: auto;
-  top: 55px;
-}
-.skill-card:hover .tooltip,
-.skill-tooltip:hover .tooltip-text {
-  visibility: visible;
-  opacity: 1;
-}
-.cardtekst {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  min-height: 95px;
 }
 .filters-container {
   display: flex;
@@ -883,23 +911,23 @@ label input {
   }
 }
 @media only screen and (max-width: 767px) {
-  .card.expanded {
-    justify-content: start;
+  .card {
+    width: 100%;
+  }
+  .project-details {
     padding: 20px;
+    gap: 14px;
   }
   .project-details .close-button {
-    margin-top: 10px;
-    margin-right: 10px;
+    margin-top: 0;
+    margin-right: 0;
   }
-  a.button.result {
+  .project-details .button.result {
     width: 100%;
-    max-width: 200px;
+    justify-content: center;
   }
   .skills {
     padding: 0 80px;
-  }
-  .tooltip {
-    top: 90px;
   }
   .settings-menu {
     top: 65px !important;

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image, { type StaticImageData } from 'next/image';
-import { useState } from 'react';
+import { useState, type KeyboardEvent, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export type ProjectSkill = {
@@ -39,7 +39,20 @@ const Card = ({
     }
   };
 
-  const handleCloseClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape' && isExpanded) {
+      event.preventDefault();
+      setIsExpanded(false);
+      return;
+    }
+
+    if (!isExpanded && (event.key === 'Enter' || event.key === ' ')) {
+      event.preventDefault();
+      setIsExpanded(true);
+    }
+  };
+
+  const handleCloseClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     setIsExpanded(false);
   };
@@ -52,30 +65,49 @@ const Card = ({
   };
 
   return (
-    <div className={`card ${isExpanded ? 'expanded' : ''} wow ${className}`} data-wow-delay={wowDelay} onClick={handleCardClick}>
+    <div
+      aria-expanded={isExpanded}
+      className={`card ${isExpanded ? 'expanded' : ''} wow ${className}`}
+      data-wow-delay={wowDelay}
+      onClick={handleCardClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+    >
       <div className="front-card">
-        <Image src={imageSrc} alt={title} sizes="(max-width: 768px) 100vw, 33vw" />
-        <h3>{title}</h3>
-        <hr />
-        <div className="cardtekst">
+        <div className="card-media">
+          <Image
+            alt={title}
+            className="project-image"
+            sizes="(max-width: 768px) 90vw, 320px"
+            src={imageSrc}
+          />
+        </div>
+
+        <div className="card-body">
+          <h3>{title}</h3>
           <p>{description}</p>
         </div>
-        <hr />
-      </div>
 
-      <div className="project-skills">
-        {skills.map((skill) => (
-          <div className="skill-tooltip" key={skill.name}>
-            <Image src={skill.image} alt={skill.name} width={48} height={48} />
-            <span className="tooltip-text">{skill.name}</span>
-          </div>
-        ))}
+        <ul className="project-skills">
+          {skills.map((skill) => (
+            <li className="skill-pill" key={skill.name}>
+              <Image alt={skill.name} height={28} src={skill.image} width={28} />
+              <span>{skill.name}</span>
+            </li>
+          ))}
+        </ul>
       </div>
 
       <div className="project-details">
         <div className="close">
-          <button className="close-button button" onClick={handleCloseClick} type="button">
-            X
+          <button
+            aria-label="Close project card"
+            className="close-button button"
+            onClick={handleCloseClick}
+            type="button"
+          >
+            ×
           </button>
         </div>
         <h3>{title}</h3>


### PR DESCRIPTION
## Summary
- redesign project cards with layered layout, keyboard accessibility, and inline skill chips
- restyle card visuals to match site accent colors and avoid layout shifts during expansion
- update mobile behaviour so details overlay stays within the original card footprint

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d13bf731e8832798465d22112dd026